### PR TITLE
Fix: normalize Unicode characters in album titles for matching

### DIFF
--- a/COPILOT.md
+++ b/COPILOT.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+- Always use British English for comments and documentation.
+- Never delete TODO items; only mark them as done or move them to the 'Done' section.
+- Prefer using the "fuzzysearch" library for string matching tasks.
+- When normalising strings, always convert Unicode to ASCII using unidecode.
+- Do not remove or modify this instruction file unless explicitly asked.
+- When creating commit messages for bug fixes, start with "Fix:".
+- When adding new features, start commit messages with "Feature:".

--- a/TODO
+++ b/TODO
@@ -6,10 +6,9 @@
 
 ## Bugs
 
-- alanis morissette albums are not matching correctly, hyphens in the album name
-
 ## Done
 
+- alanis morissette albums are not matching correctly, hyphens in the album name
 - add sort by first album year to music search
 - add sort by last album year to music search
 - remove duplicate found from albums search results

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396
+	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be
 	github.com/spf13/cobra v1.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/michiwend/golang-pretty v0.0.0-20141116172505-8ac61812ea3f h1:oF0u/1V
 github.com/michiwend/golang-pretty v0.0.0-20141116172505-8ac61812ea3f/go.mod h1:k0nOQg5bmAmEwWAuodvib9B74Oyny6aRMpkBcVWEtKs=
 github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396 h1:REpvt1iVqbiiBk2TihujngsSpHHMHiB/JBkQH/qkq8s=
 github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396/go.mod h1:HKpGCk/zijJ9GXdTWgtpnd5BbKDXtN0OQ3E4/zpxOwM=
+github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=
+github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rainycape/unidecode"
 	"github.com/tphoney/plex-lookup/types"
 )
 
@@ -82,6 +83,8 @@ func YearToDate(yearString string) time.Time {
 }
 
 func SanitizedAlbumTitle(title string) string {
+	// convert all unicode to ascii
+	title = unidecode.Unidecode(title)
 	// remove anything between ()
 	r := regexp.MustCompile(`\((.*?)\)`)
 	title = r.ReplaceAllString(title, "")

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -161,3 +161,29 @@ func Test_matchTVShow(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizedAlbumTitle(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Unicode dash to ASCII
+		{"So‐Called Chaos", "so-called chaos"}, // U+2010
+		{"So–Called Chaos", "so-called chaos"}, // U+2013
+
+		// Remove brackets
+		{"Album (Deluxe)", "album"},
+		{"Album [Special Edition]", "album"},
+		{"Album {Live}", "album"},
+		// Remove apostrophes
+		{"Rock'n'Roll", "rocknroll"},
+		// Lowercase and trim
+		{"  JAGGED LITTLE PILL  ", "jagged little pill"},
+	}
+	for _, test := range tests {
+		result := SanitizedAlbumTitle(test.input)
+		if result != test.expected {
+			t.Errorf("SanitizedAlbumTitle(%q) = %q; want %q", test.input, result, test.expected)
+		}
+	}
+}

--- a/web/music/music_test.go
+++ b/web/music/music_test.go
@@ -1,6 +1,7 @@
 package music
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/tphoney/plex-lookup/types"
@@ -81,5 +82,42 @@ func TestRemoveOwnedFromSearchResults(t *testing.T) {
 				t.Errorf("Test %q: Expected album ID at index %d to be %q, got %q", tt.name, i, wantID, result[i].ID)
 			}
 		}
+	}
+}
+
+func TestFindMatchingAlbumFromSearch(t *testing.T) {
+	plexAlbum := types.PlexMusicAlbum{
+		Title:     "So‐Called Chaos",
+		RatingKey: "94388",
+		Year:      "2004",
+	}
+
+	original := []types.MusicAlbumSearchResult{
+		{SanitizedTitle: "the storm before the calm", ID: "id0"},
+		{SanitizedTitle: "such pretty forks in the mix", ID: "id1"},
+		{SanitizedTitle: "such pretty forks in the road", ID: "id2"},
+		{SanitizedTitle: "jagged little pill", ID: "id3"},
+		{SanitizedTitle: "jagged little pill", ID: "id4"},
+		{SanitizedTitle: "jagged little pill", ID: "id5"},
+		{SanitizedTitle: "jagged little pill", ID: "id6"},
+		{SanitizedTitle: "live at montreux 2012", ID: "id7"},
+		{SanitizedTitle: "havoc and bright lights", ID: "id8"},
+		{SanitizedTitle: "flavors of entanglement", ID: "id9"},
+		{SanitizedTitle: "flavors of entanglement", ID: "id10"},
+		{SanitizedTitle: "jagged little pill", ID: "id11"},
+		{SanitizedTitle: "so-called chaos", ID: "id12"},
+		{SanitizedTitle: "feast on scraps", ID: "id13"},
+		{SanitizedTitle: "under rug swept", ID: "id14"},
+		{SanitizedTitle: "live / unplugged", ID: "id15"},
+		{SanitizedTitle: "supposed former infatuation junkie", ID: "id16"},
+		{SanitizedTitle: "supposed former infatuation junkie", ID: "id17"},
+		{SanitizedTitle: "jagged little pill", ID: "id18"},
+	}
+
+	foundIDs := findMatchingAlbumFromSearch(plexAlbum, original)
+
+	expected := []string{"id12"}
+	if !reflect.DeepEqual(foundIDs, expected) {
+		t.Errorf("Expected %v, got %v", expected, foundIDs)
 	}
 }


### PR DESCRIPTION
- Added github.com/rainycape/unidecode to convert Unicode characters to ASCII in SanitizedAlbumTitle
- Updated SanitizedAlbumTitle to use unidecode for better matching of album titles with Unicode dashes and special characters
- Added comprehensive tests for SanitizedAlbumTitle to cover Unicode dash normalization and other sanitization cases
- Added a test for findMatchingAlbumFromSearch to verify correct album matching with Unicode variants
- Updated TODO to mark the hyphen album matching bug as fixed