### PR TITLE
fix, bluray.com agent fix

### DIFF
--- a/amazon/amazon.go
+++ b/amazon/amazon.go
@@ -439,7 +439,7 @@ func makeRequest(inputURL, region string) (response string, err error) {
 	req, err := http.NewRequestWithContext(context.Background(), "GET", inputURL, bytes.NewBuffer([]byte{}))
 
 	req.Header.Set("User-Agent",
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
 
 	req.Header.Set("Cookie", fmt.Sprintf("country=%s;", region))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the HTTP `User-Agent` header string used in `makeRequest`, which may affect how the upstream site responds but doesn’t change local data handling or logic.
> 
> **Overview**
> Updates `amazon.makeRequest` to send a newer Chrome-based `User-Agent` header when scraping blu-ray.com, to improve request compatibility with the upstream site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb89d8ede0b876882a114c2728bb62fc835632ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->